### PR TITLE
Add a missing definition for \bxpi@warn

### DIFF
--- a/bxjaprnind.sty
+++ b/bxjaprnind.sty
@@ -7,6 +7,7 @@
 
 \def\bxpi@pkgname{bxjaprnind}
 \def\bxpi@error{\PackageError\bxpi@pkgname}
+\def\bxpi@warn{\PackageWarning\bxpi@pkgname}
 
 %% definitions
 \newdimen\bxpi@dima


### PR DESCRIPTION
This package issues an error if `\inhibitglue` is undefined at the time of loading; e.g.,

```latex
\documentclass{article}
\usepackage{bxjaprnind}
\usepackage{luatexja}
\begin{document}
\end{document}
```

yields

```console
! Undefined control sequence.
<argument> \let \bxpi@inhibitglue \relax \bxpi@warn
                                         {\string \inhibitglue \space unavailab
l.88 }

?
```

We should load `luatexja` before `bxjaprnind` in this case, but `\bxpi@warn` should be defined anyway.